### PR TITLE
Add as() to force cast to the impl type in Type

### DIFF
--- a/include/types/type.h
+++ b/include/types/type.h
@@ -9,6 +9,17 @@ class Type {
   virtual void accept(Visitor& visitor) const = 0;
 
  public:
+  template <typename T>
+  T* as() {
+    return dynamic_cast<T*>(this);
+  }
+
+  template <typename T>
+  const T* as() const {
+    return dynamic_cast<const T*>(this);
+  }
+
+ public:
   const bool operator==(const Type& other) const;
   const bool operator!=(const Type& other) const;
 


### PR DESCRIPTION
* This breaks it being an interface but that is okay since this is only one level of inheritance.