### PR TITLE
Remove type() from Nodes

### DIFF
--- a/include/nodes/array.h
+++ b/include/nodes/array.h
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "node.h"
-#include "type.h"
 
 namespace json {
 
@@ -20,9 +19,6 @@ class Array : public Node {
  public:
   std::vector<Node*>& get();
   const std::vector<Node*>& get() const;
-
- public:
-  const Type type() const override;
 
  private:
   std::vector<Node*> array_;

--- a/include/nodes/boolean.h
+++ b/include/nodes/boolean.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "node.h"
-#include "type.h"
 
 namespace json {
 
@@ -14,10 +13,8 @@ class Boolean : public Node {
   Boolean(const bool value);
 
  public:
-  const bool get() const;
-
- public:
-  const Type type() const override;
+  bool& get();
+  const bool& get() const;
 
  private:
   bool value_;

--- a/include/nodes/node.h
+++ b/include/nodes/node.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "type.h"
 
 namespace json {
 
@@ -23,9 +22,6 @@ class Node {
   }
 
  public:
-  virtual const Type type() const = 0;
-
- public:
   const bool operator==(const Node& other) const;
   const bool operator!=(const Node& other) const;
 
@@ -38,7 +34,6 @@ class Boolean;
 class Null;
 class Number;
 class Object;
-class KeyValue;
 class String;
 
 }  // namespace json

--- a/include/nodes/null.h
+++ b/include/nodes/null.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "node.h"
-#include "type.h"
 
 namespace json {
 
@@ -9,9 +8,6 @@ class Null : public Node {
  public:
   void accept(Visitor& visitor) const override;
   Node* accept(ReturnVisitor& visitor) const override;
-
- public:
-  const Type type() const override;
 };
 
 }  // namespace json

--- a/include/nodes/number.h
+++ b/include/nodes/number.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "node.h"
-#include "type.h"
 
 namespace json {
 
@@ -14,10 +13,8 @@ class Number : public Node {
   Number(const double value);
 
  public:
-  const double get() const;
-
- public:
-  const Type type() const override;
+  double& get();
+  const double& get() const;
 
  private:
   double value_;

--- a/include/nodes/object.h
+++ b/include/nodes/object.h
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "node.h"
-#include "type.h"
 #include "utils/rbt.h"
 
 namespace json {
@@ -22,9 +21,6 @@ class Object : public Node {
  public:
   utils::Map<std::string, Node*>& get();
   const utils::Map<std::string, Node*>& get() const;
-
- public:
-  const Type type() const override;
 
  private:
   utils::Map<std::string, Node*> properties_;

--- a/include/nodes/string.h
+++ b/include/nodes/string.h
@@ -3,7 +3,6 @@
 #include <string>
 
 #include "node.h"
-#include "type.h"
 
 namespace json {
 
@@ -16,10 +15,8 @@ class String : public Node {
   String(std::string value);
 
  public:
+  std::string& get();
   const std::string& get() const;
-
- public:
-  const Type type() const override;
 
  private:
   std::string value_;

--- a/include/nodes/type.h
+++ b/include/nodes/type.h
@@ -1,3 +1,0 @@
-#pragma once
-
-enum class Type { ARRAY, BOOLEAN, JSON_NULL, NUMBER, OBJECT, STRING };

--- a/src/nodes/array.cc
+++ b/src/nodes/array.cc
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "nodes/node.h"
-#include "nodes/type.h"
 #include "visitors/ret_visitor.h"
 #include "visitors/visitor.h"
 
@@ -24,7 +23,5 @@ const bool Array::empty() const { return array_.empty(); }
 std::vector<Node*>& Array::get() { return array_; }
 
 const std::vector<Node*>& Array::get() const { return array_; }
-
-const Type Array::type() const { return Type::ARRAY; }
 
 }  // namespace json

--- a/src/nodes/boolean.cc
+++ b/src/nodes/boolean.cc
@@ -1,6 +1,5 @@
 #include "nodes/boolean.h"
 
-#include "nodes/type.h"
 #include "visitors/ret_visitor.h"
 #include "visitors/visitor.h"
 
@@ -14,8 +13,8 @@ Node* Boolean::accept(ReturnVisitor& visitor) const {
 
 Boolean::Boolean(const bool value) : value_(value) {}
 
-const bool Boolean::get() const { return value_; }
+bool& Boolean::get() { return value_; }
 
-const Type Boolean::type() const { return Type::BOOLEAN; }
+const bool& Boolean::get() const { return value_; }
 
 }  // namespace json

--- a/src/nodes/null.cc
+++ b/src/nodes/null.cc
@@ -1,6 +1,5 @@
 #include "nodes/null.h"
 
-#include "nodes/type.h"
 #include "visitors/ret_visitor.h"
 #include "visitors/visitor.h"
 
@@ -11,7 +10,5 @@ void Null::accept(Visitor& visitor) const { visitor.visit(*this); }
 Node* Null::accept(ReturnVisitor& visitor) const {
   return visitor.visit(*this);
 }
-
-const Type Null::type() const { return Type::JSON_NULL; }
 
 }  // namespace json

--- a/src/nodes/number.cc
+++ b/src/nodes/number.cc
@@ -1,6 +1,5 @@
 #include "nodes/number.h"
 
-#include "nodes/type.h"
 #include "visitors/ret_visitor.h"
 #include "visitors/visitor.h"
 
@@ -14,8 +13,8 @@ Node* Number::accept(ReturnVisitor& visitor) const {
 
 Number::Number(double value) : value_(value) {}
 
-const double Number::get() const { return value_; }
+double& Number::get() { return value_; }
 
-const Type Number::type() const { return Type::NUMBER; }
+const double& Number::get() const { return value_; }
 
 }  // namespace json

--- a/src/nodes/object.cc
+++ b/src/nodes/object.cc
@@ -1,6 +1,5 @@
 #include "nodes/object.h"
 
-#include "nodes/type.h"
 #include "utils/rbt.h"
 #include "visitors/ret_visitor.h"
 #include "visitors/visitor.h"
@@ -26,7 +25,5 @@ utils::Map<std::string, Node*>& Object::get() { return properties_; }
 const utils::Map<std::string, Node*>& Object::get() const {
   return properties_;
 }
-
-const Type Object::type() const { return Type::OBJECT; }
 
 }  // namespace json

--- a/src/nodes/string.cc
+++ b/src/nodes/string.cc
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "nodes/type.h"
 #include "visitors/ret_visitor.h"
 #include "visitors/visitor.h"
 
@@ -16,8 +15,8 @@ Node* String::accept(ReturnVisitor& visitor) const {
 
 String::String(std::string value) : value_(std::move(value)) {}
 
-const std::string& String::get() const { return value_; }
+std::string& String::get() { return value_; }
 
-const Type String::type() const { return Type::STRING; }
+const std::string& String::get() const { return value_; }
 
 }  // namespace json


### PR DESCRIPTION
* This implementation should be opinionated. We will be using the visitor pattern for any type-related operations.
* Also, return the reference + provide a non-const version of get().