### PR TITLE
Erase array element instead of nulling it out on move

### DIFF
--- a/src/json/value.cc
+++ b/src/json/value.cc
@@ -61,7 +61,7 @@ Value& Value::operator=(Value&& other) {
 
       // null out other's AST
       other.parent_->node_->accept(visitor);
-      visitor.result()[std::stoi(*other.key_)] = new Null();
+      visitor.result().erase(visitor.result().begin() + std::stoi(*other.key_));
 
       // move to current AST
       parent_->node_->accept(visitor);

--- a/tests/json/value_test.cc
+++ b/tests/json/value_test.cc
@@ -604,7 +604,6 @@ TEST_F(ValueTest, ArrayMoveSemantics) {
 
   // assert
   json::Array expected_arr1;
-  expected_arr1.get().push_back(new json::Null());
   expected_arr1.get().push_back(new json::String("value2"));
   expected_arr1.get().push_back(new json::String("value3"));
 


### PR DESCRIPTION
* This is probably desired since we should be able to change the container
  elements. I guess I implemented it by just nulling the element out to make
  sure that it worked in the first place.